### PR TITLE
[TASK] Allow TYPO v11 and v12

### DIFF
--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -1,0 +1,89 @@
+name: tests core 12
+
+on:
+  pull_request:
+
+jobs:
+  code-quality:
+    name: "code quality with core v12"
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ '8.1']
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Link docker compose"
+        run: |
+          echo "#!/usr/bin/env bash" > /usr/local/bin/docker-compose
+          echo "" >> /usr/local/bin/docker-compose
+          echo "docker compose \"\$@\"" >> /usr/local/bin/docker-compose
+          chmod a+x /usr/local/bin/docker-compose
+
+      - name: "Prepare dependencies for TYPO3 v11"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Run TypoScript lint"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintTypoScript"
+
+      - name: "Run PHP lint"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
+
+      - name: "Validate CGL"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl"
+
+#      - name: "Ensure tests methods do not start with \"test\""
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
+
+      - name: "Ensure UTF-8 files do not contain BOM"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkBom"
+
+      - name: "Test .rst files for integrity"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkRst"
+
+#      - name: "Find duplicate exception codes"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+
+      - name: "Run PHPStan"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s phpstan"
+
+#  testsuite:
+#    name: all tests with core v12
+#    runs-on: ubuntu-22.04
+#    needs: code-quality
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        php-version: [ '8.0', '8.1', '8.2' ]
+#    steps:
+#      - name: "Checkout"
+#        uses: actions/checkout@v3
+
+#      - name: "Prepare dependencies for TYPO3 v12"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
+
+#      - name: "Unit"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s unit"
+
+#      - name: "Functional SQLite"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d sqlite"
+
+#      - name: "Functional MariaDB 10.5 mysqli"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+
+#      - name: "Functional MariaDB 10.5 pdo_mysql"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+
+#      - name: "Functional MySQL 8.0 mysqli"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+
+#      - name: "Functional MySQL 8.0 pdo_mysql"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+
+#      - name: "Functional PostgresSQL 10"
+#        # v11 postgres functional disabled with PHP 8.2 since https://github.com/doctrine/dbal/commit/73eec6d882b99e1e2d2d937accca89c1bd91b2d7
+#        # is not fixed in doctrine core v11 doctrine 2.13.9
+#        if: ${{ matrix.php <= '8.1' }}
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/Build/phpstan/Core11/phpstan-baseline.neon
+++ b/Build/phpstan/Core11/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContextInterface\\:\\:getRequest\\(\\)\\.$#"
-			count: 1
-			path: ../../../Classes/ViewHelpers/Be/ImageIdViewHelper.php
-
-		-
 			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
 			count: 1
 			path: ../../../ext_emconf.php

--- a/Build/phpstan/Core12/phpstan.neon
+++ b/Build/phpstan/Core12/phpstan.neon
@@ -9,10 +9,9 @@ parameters:
 	level: 8
 
 	paths:
-		- ../../../Classes
-		- ../../../Tests/
+		- ../../../
 
 	excludePaths:
 		- ../../../.Build
-		- ../../../Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_emconf.php
-		- ../../../Classes/Override/Core11
+		- ../../../.cache
+		- ../../../Build

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,1 @@
+templates.typo3/cms-backend.1726590509409 = fgtclb/page-backend-layout:Resources/Private/Backend

--- a/Resources/Private/Backend/Templates/PageLayout/PageLayout.html
+++ b/Resources/Private/Backend/Templates/PageLayout/PageLayout.html
@@ -1,6 +1,6 @@
 <html
-    xmlns:f="https://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
-    xmlns:be="https://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
     data-namespace-typo3-fluid="true"
 >
 <f:render partial="PageLayout/Doktype{context.pageRecord.doktype}" arguments="{_all}" optional="true"/>

--- a/composer.json
+++ b/composer.json
@@ -28,19 +28,19 @@
 	},
 	"require": {
 		"php": "^7.4 || ^8.0 || ^8.1 || ^8.2",
-		"typo3/cms-core": "^11.5"
+		"typo3/cms-core": "^11.5 || ^12.4"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.14",
 		"phpstan/phpstan": "^1.10",
 		"saschaegerer/phpstan-typo3": "^1.8",
-		"typo3/cms-extensionmanager": "^11.5",
-		"typo3/cms-fluid-styled-content": "^11.5",
-		"typo3/cms-fluid": "^11.5",
-		"typo3/cms-frontend": "^11.5",
-		"typo3/cms-info": "^11.5",
-		"typo3/cms-lowlevel": "^11.5",
-		"typo3/cms-tstemplate": "^11.5",
+		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
+		"typo3/cms-fluid": "^11.5 || ^12.4",
+		"typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
+		"typo3/cms-frontend": "^11.5 || ^12.4",
+		"typo3/cms-info": "^11.5 || ^12.4",
+		"typo3/cms-lowlevel": "^11.5 || ^12.4",
+		"typo3/cms-tstemplate": "^11.5 || ^12.4",
 		"typo3/coding-standards": "^0.6.1"
 	},
 	"autoload": {

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -1,3 +1,4 @@
+# @todo Silently ignored with TYPO3 v12 and will be dropped in 2.x
 module.tx_backend {
   view {
     templateRootPaths {


### PR DESCRIPTION
First change allows TYPO3 v12, albeit not
tackling issues for now.

Used command(s):

```shell
composer require --no-update \
    "typo3/cms-core":"^11.5 || ^12.4" \
&& composer require --dev --no-update \
    "typo3/cms-extensionmanager":"^11.5 || ^12.4" \
    "typo3/cms-fluid-styled-content":"^11.5 || ^12.4" \
    "typo3/cms-fluid":"^11.5 || ^12.4" \
    "typo3/cms-frontend":"^11.5 || ^12.4" \
    "typo3/cms-info":"^11.5 || ^12.4" \
    "typo3/cms-lowlevel":"^11.5 || ^12.4" \
    "typo3/cms-tstemplate":"^11.5 || ^12.4"
```

The second change adjust minor code places to be
TYPO3 v11 and v12 compatible, including:

* Using TYPO3 v12 page.tsconfig to register backend
  templates.
* Avoid deprecated compile static viewhelper.

