### PR TITLE
[BUGFIX] Language comparison fix

### DIFF
--- a/Resources/Private/Backend/Templates/PageLayout/PageLayout.html
+++ b/Resources/Private/Backend/Templates/PageLayout/PageLayout.html
@@ -1,10 +1,15 @@
 <html
+    lang="en"
     xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
     xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
     data-namespace-typo3-fluid="true"
 >
 <f:render partial="PageLayout/Doktype{context.pageRecord.doktype}" arguments="{_all}" optional="true"/>
-<f:if condition="{context.drawingConfiguration.languageMode}">
+<f:comment><!--
+TYPO3 12: languageMode
+TYPO3 13: languageComparisonMode
+--></f:comment>
+<f:if condition="{context.drawingConfiguration.languageMode} || {context.drawingConfiguration.languageComparisonMode}">
     <f:then>
         <f:render partial="PageLayout/LanguageColumns" arguments="{_all}" />
     </f:then>


### PR DESCRIPTION
TYPO3 13 changed behaviour in `DrawingConfiguration` in favour of a directly callable
`langaugeTranslationMode` instead of the dropped `languageMode`. On updating this
extension, this was not checked and therefore not handled.

With this commit the condition inside the `PageLayout` is adjusted respecting both
TYPO3 12 and 13 in handling the current DrawingConfiguration and rendering the
respective necessary Partial.
