### PR TITLE
[BUGFIX] Ensure renderChildrenClouse built correct

### DIFF
--- a/Classes/ViewHelpers/Be/ImageIdViewHelper.php
+++ b/Classes/ViewHelpers/Be/ImageIdViewHelper.php
@@ -46,7 +46,7 @@ class ImageIdViewHelper extends AbstractViewHelper
         $arguments = $this->arguments;
         /** @var RenderingContext $renderingContext */
         $renderingContext = $this->renderingContext;
-        $renderChildrenClosure = $this->renderChildrenClosure;
+        $renderChildrenClosure = $this->buildRenderChildrenClosure();
 
         /** @var ServerRequestInterface|null $request */
         $request = $renderingContext->getRequest();


### PR DESCRIPTION
The ViewHelper uses the renderChildrenClosure to render the content.

Besides the AbstractViewHelper having a property `renderChildrenClosure`, it is not safe this property is set correct. Use the `buildRenderChildrenClosure` method ensures the context is rendered as wanted and can be accessed.