### PR TITLE
[BUGFIX] Ensure renderChildrenClouse built correct

### DIFF
--- a/Classes/ViewHelpers/Be/ImageIdViewHelper.php
+++ b/Classes/ViewHelpers/Be/ImageIdViewHelper.php
@@ -48,7 +48,7 @@ class ImageIdViewHelper extends AbstractViewHelper
         $arguments = $this->arguments;
         /** @var RenderingContext $renderingContext */
         $renderingContext = $this->renderingContext;
-        $renderChildrenClosure = $this->renderChildrenClosure;
+        $renderChildrenClosure = $this->buildRenderChildrenClosure();
 
         $request = $renderingContext->getRequest();
         if ($request === null) {


### PR DESCRIPTION
The ViewHelper uses the renderChildrenClosure to render the content.

Besides the AbstractViewHelper having a property `renderChildrenClosure`, it is not safe this property is set correct. Use the `buildRenderChildrenClosure` method ensures the context is rendered as wanted and can be accessed.