### PR TITLE
[TASK] Run CI containers with docker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,15 @@
 name: publish
+
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   push:
     tags:
@@ -61,7 +72,7 @@ jobs:
 #        id: rendering
 #        run: |
 #          mkdir -p tailor-version-artefact/
-#          Build/Scripts/runTests.sh -b podman -s renderDocumentation || true
+#          Build/Scripts/runTests.sh -b docker -s renderDocumentation || true
 #          zip -r tailor-version-artefact/documentation-${{ env.version }}.zip Documentation-GENERATED-temp/
 
       # Note that when release already exists for tag, only files will be uploaded and lets this acting as a

--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -1,5 +1,15 @@
 name: tests core 12
 
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   pull_request:
 
@@ -43,28 +53,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v12"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composer require typo3/cms-core:^12.4"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s composer require typo3/cms-core:^12.4"
 
 #      - name: "Run TypoScript lint"
-#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintTypoScript"
+#        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s lintTypoScript"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s cgl"
 
 #      - name: "Ensure tests methods do not start with \"test\""
-#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
+#        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
 
       - name: "Ensure UTF-8 files do not contain BOM"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkBom"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s checkBom"
 
       - name: "Test .rst files for integrity"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkRst"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s checkRst"
 
 #      - name: "Find duplicate exception codes"
-#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+#        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s checkExceptionCodes"
 
       - name: "Run PHPStan"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s phpstan"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s phpstan"

--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -1,5 +1,15 @@
 name: tests core 13
 
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   pull_request:
 
@@ -43,28 +53,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v13"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s composer require typo3/cms-core:^13.4"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s composer require typo3/cms-core:^13.4"
 
 #      - name: "Run TypoScript lint"
-#        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s lintTypoScript"
+#        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s lintTypoScript"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s cgl"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s cgl"
 
 #      - name: "Ensure tests methods do not start with \"test\""
-#        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
+#        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
 
       - name: "Ensure UTF-8 files do not contain BOM"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkBom"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkBom"
 
       - name: "Test .rst files for integrity"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkRst"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkRst"
 
 #      - name: "Find duplicate exception codes"
-#        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+#        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkExceptionCodes"
 
       - name: "Run PHPStan"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s phpstan"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s phpstan"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -10,10 +10,13 @@ fi
 waitFor() {
     local HOST=${1}
     local PORT=${2}
+    # 60 rather than 10 seconds: mysql:8.0 needs 12-13s under docker to
+    # initialise a fresh data directory, about twice as long as under podman,
+    # so an 11 second budget aborted the functional mysql suites at random.
     local TESTCOMMAND="
         COUNT=0;
         while ! nc -z ${HOST} ${PORT}; do
-            if [ \"\${COUNT}\" -gt 10 ]; then
+            if [ \"\${COUNT}\" -gt 60 ]; then
               echo \"Can not connect to ${HOST} port ${PORT}. Aborting.\";
               exit 1;
             fi;
@@ -23,7 +26,11 @@ waitFor() {
     "
     ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name wait-for-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} /bin/sh -c "${TESTCOMMAND}"
     if [[ $? -gt 0 ]]; then
-        kill -SIGINT -$$
+        # Not "kill -SIGINT -$$": the SIGINT trap is only installed when CI is
+        # not "true", so in CI the signal was a no-op, the run continued and the
+        # test suite connected to a database that was not listening.
+        cleanUp
+        exit 1
     fi
 }
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -523,12 +523,20 @@ case ${TEST_SUITE} in
         ;;
     composer)
         COMMAND=(composer "$@")
-        ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_POLICY_ADVISORIES_BLOCK=false -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         SUITE_EXIT_CODE=$?
         ;;
     composerUpdate)
+        # Composer 2.10 blocks advisory-affected versions from the resolver pool by
+        # default. TYPO3 versions past free support are permanently advisory-affected,
+        # so they drop out entirely and leave only releases requiring a newer PHP -
+        # surfacing as a misleading "your php version does not satisfy that
+        # requirement" error instead of anything mentioning advisories. Testing the
+        # versions this extension supports requires installing them. Kept in the
+        # harness on purpose: composer.json would disable the check for consumers of
+        # this package too.
         COMMAND=(Build/Scripts/composer-for-core-version.sh ${CORE_VERSION})
-        ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_POLICY_ADVISORIES_BLOCK=false -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         SUITE_EXIT_CODE=$?
         ;;
     functional)

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -554,7 +554,13 @@ case ${TEST_SUITE} in
             sqlite)
                 # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid"
+                # "mode=1777" is required for docker and harmless for podman: docker runs
+                # the container as "--user $HOST_UID" with group 0, while the tmpfs comes
+                # up owned by root with mode 0755, so the test databases cannot be created
+                # and every test fails with "unable to open database file". Rootless podman
+                # passes no "--user" (it is root inside its user namespace), which is why
+                # this only shows with docker.
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;


### PR DESCRIPTION
## Why

GitHub hosted runners ship both podman and docker. Since 2026-07-29 their
podman/crun combination intermittently aborts the **first container start of a
job** with

```
Error: OCI runtime error: crun: unknown version specified
```

exit code 126. It is independent of the job, the core version and the PHP
version, and a rerun on another host clears it. Neither the runner image nor the
TYPO3 testing image changed, so this is variance in the GitHub host fleet.

## The change

`Build/Scripts/runTests.sh` prefers podman whenever it is present and only falls
back to docker. That default is correct for the script — podman-only machines
are exactly what it is built for — so it stays. The GitHub hosted runners are
the single place these workflows meet the broken combination, so the override
belongs in the workflows.

Every `runTests.sh` call now passes `-b docker`, with the reasoning in the
workflow header so the flag can be dropped knowingly once GitHub stops producing
the mismatch.

This mirrors what is already merged across the `deepl*` extension family, and
originates from fgtclb/academic-extensions.

## Companion fixes

Selecting docker exposes defects that podman masked. Only the ones that apply to
this repository are included — see the summary below.

* **sqlite tmpfs `mode=1777`** — docker runs the container as
  `--user $HOST_UID` with group 0, while the tmpfs inherits the mode of its host
  mountpoint (`0755 root:root` at a runner's umask). No test database can be
  created, and every functional sqlite test fails with `unable to open database
  file`. Rootless podman is root inside its user namespace and passes no
  `--user`, which is why this never showed. `mode=1777` fixes it for both
  runtimes and makes the suite umask-independent.
* **hardcoded `-it`** — the documentation rendering run hardcoded `-it` on top of
  the interactivity the script already manages. docker rejects `-t` without a
  TTY, so that suite cannot run under docker in CI.
* **`waitFor()` readiness cap** — the poll aborted after ~11 s. `mysql:8.0`
  needs 12–13 s to become ready under docker versus 7 s under podman, and
  mariadb 8.2 s. The cap is 60 s now. The abort itself also never fired in CI,
  because `kill -SIGINT -$$` relies on a SIGINT trap that is only installed when
  `CI` is not `"true"` — so the suite ran against a database that was not
  listening and reported misleading `Connection refused` errors.

## Applied here

* `-b docker` on 19 `runTests.sh` calls across `.github/workflows/publish.yml`,
  `.github/workflows/testcore12.yml`, `.github/workflows/testcore13.yml`
  (9 + 9 in the two test workflows, 1 in `publish.yml`). The 20th call, in
  `.github/workflows/documentation.yml.disabled`, already passed `-b docker` and
  is untouched. `.github/workflows/testcore11.yml` contains no call and stays
  byte-identical.
* The `publish.yml` call is a release path: it sat at `-b podman` and is now
  `-b docker`. It is inside a commented-out "Render documentation" step, so it is
  not active today — it is aligned so re-enabling it cannot reintroduce the bug.
* Commented-out calls in `testcore12.yml` / `testcore13.yml` (TypoScript lint,
  test-method prefix, exception codes) get the flag for the same reason.
* sqlite tmpfs `mode=1777`: yes
* hardcoded `-it` removed: left latent (`renderDocumentation`) — no active
  workflow invokes that suite. It is reached only from
  `documentation.yml.disabled` and from the commented-out step in `publish.yml`.
* `waitFor` cap 11s -> 60s: yes, plus `kill -SIGINT -$$` replaced by
  `cleanUp; exit 1` (second commit).
