### PR TITLE
[TASK] WVP-113: runTests.sh follow-ups

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -397,6 +397,7 @@ handleDbmsOptions
 
 COMPOSER_ROOT_VERSION="5.x.x-dev"
 HOST_UID=$(id -u)
+HOST_GID=$(id -g)
 USERSET=""
 if [ $(uname) != "Darwin" ]; then
     USERSET="--user $HOST_UID"
@@ -460,9 +461,25 @@ if [ "${CONTAINER_BIN}" == "docker" ]; then
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm ${USERSET} -v ${ROOT_DIR}:/project"
+    # docker creates a tmpfs owned by "root:root", inheriting the mode of its host
+    # mountpoint, while "${USERSET}" above passes a uid but no group and therefore runs
+    # the container as "uid=${HOST_UID} gid=0". At a CI umask of 0022 the mountpoint is
+    # 0755, so group 0 gets "r-x" and no test database can be created.
+    #
+    # "uid"/"gid" address that at the source: the mount is owned by the user the container
+    # runs as, whatever the umask of the host mountpoint. "mode=1777" is the workaround the
+    # docker adoption introduced instead, and is kept next to them - it is what has been
+    # proven on a GitHub hosted runner, and it costs nothing to leave in place.
+    #
+    # None of this reproduces at the 0002 umask of a typical workstation, where the
+    # mountpoint comes up 0775 and the group bit already grants access. Use "umask 0022".
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,uid=${HOST_UID},gid=${HOST_GID},mode=1777"
 else
     # podman
     CONTAINER_HOST="host.containers.internal"
+    # Rootless podman maps the container root to the host user, so the tmpfs is writable
+    # without an explicit owner. "mode=1777" is kept for the rootful case.
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,mode=1777"
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} -v ${ROOT_DIR}:/project"
@@ -569,13 +586,11 @@ case ${TEST_SUITE} in
             sqlite)
                 # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
-                # "mode=1777" is required for docker and harmless for podman: docker runs
-                # the container as "--user $HOST_UID" with group 0, while the tmpfs comes
-                # up owned by root with mode 0755, so the test databases cannot be created
-                # and every test fails with "unable to open database file". Rootless podman
-                # passes no "--user" (it is root inside its user namespace), which is why
-                # this only shows with docker.
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777"
+                # "${TMPFS_MOUNT_OPTIONS}" carries the owner and mode the mount needs, which
+                # differ per container binary - see where it is assigned. Without them the
+                # test databases cannot be created and every test fails with "unable to open
+                # database file".
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:${TMPFS_MOUNT_OPTIONS}"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -607,7 +607,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     renderDocumentation)
-        ${CONTAINER_BIN} run ${DOCUMENTATION_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project -v ${ROOT_DIR}:/project -it ${IMAGE_DOCS} --config=Documentation --fail-on-error --no-progress --config=Documentation Documentation "$@"
+        ${CONTAINER_BIN} run ${DOCUMENTATION_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project ${IMAGE_DOCS} --config=Documentation --fail-on-error --no-progress --config=Documentation Documentation "$@"
         SUITE_EXIT_CODE=$?
         ;;
     phpstan)


### PR DESCRIPTION
Follow-up work from WVP-113 for branch `main`. Two of the issue's tasks
still apply here, both in `Build/Scripts/runTests.sh`; no workflow file is
touched.

## What applied

**T3 — `--user` passes a uid but no group** (commit 1)

`USERSET` is `--user $HOST_UID`, so a docker container runs as
`uid=$HOST_UID gid=0(root)`. A `--tmpfs` comes up `root:root` and inherits the
mode of its host mountpoint — 0755 at a CI umask of 0022 — so group 0 gets
`r-x` and the functional sqlite suite fails with *unable to open database
file*. The docker adoption worked around this with `mode=1777` on the one
mount; this addresses the owner instead.

The mount options move into `TMPFS_MOUNT_OPTIONS`, assigned per container
binary next to the parameters they belong to:

* docker: `rw,noexec,nosuid,uid=${HOST_UID},gid=${HOST_GID},mode=1777`
* podman: `rw,noexec,nosuid,mode=1777`

The existing `mode=1777` is deliberately kept — it is what has been proven on a
GitHub hosted runner. `USERSET` is deliberately left alone: it is evaluated for
both container binaries, and appending a group there would change which host
group rootless podman maps the container to.

**T2 — `renderDocumentation` hardcodes `-it`** (commit 2)

The run line already expanded `DOCUMENTATION_COMMON_PARAMS` and then appended a
second, hardcoded `-it`. That defeats exactly what the parameters take care of:
`CONTAINER_INTERACTIVE` is `-it --init` for a shell and is emptied when
`CI=true`, because a hosted runner has no tty. The trailing `-it` put it back,
and the container aborts with *the input device is not a TTY* as soon as the
suite runs unattended. The flag is dropped, so interactivity is decided in one
place again; nothing changes locally.

The run line also repeated `-v ${ROOT_DIR}:/project`, which both branches of
`DOCUMENTATION_COMMON_PARAMS` already carry. It is dropped with it.

This is latent today: the only caller is
`.github/workflows/documentation.yml.disabled`, which GitHub does not load
because of the file name suffix. **That is the point of fixing it now** — it has
to land before that workflow is renamed to `.yml`, not after. Renaming the file
is not part of this pull request.

## What did not apply

* **T4 — dead `CI_PARAMS` / `DOCUMENTATION_COMMON_PARAMS`.** Does not apply, and
  the issue already says so correctly. `CI_PARAMS="${CI_PARAMS:-}"` is assigned
  and genuinely consumed on the podman branch; `DOCUMENTATION_COMMON_PARAMS` is
  assigned for both binaries and genuinely consumed by `renderDocumentation`.
* **Explicit `-i <version>` on functional steps.** Nothing to do: no workflow
  step on `main` invokes `-s functional` at all. Parsed with `yaml.safe_load`,
  the live jobs are `testcore12.yml` → `code-quality`, `testcore13.yml` →
  `code-quality`, `testcore11.yml` → a single `dummy` job on `workflow_dispatch`
  (badge placeholder). There is therefore no label work and no workflow diff.
* **T5 — legacy docker-compose harness.** Branch `1` only; `main` is already the
  `CONTAINER_BIN` harness. Out of scope here, stays open.
* **Branch `1`.** Explicitly out of scope. T2 and T3 do not exist there —
  `renderDocumentation` is `docker-compose run render_documentation` and there is
  no `USERSET` at all.

## Corrections to the issue / matrix

* The portfolio matrix claims *"4 live mislabelled MySQL steps on branch 1"*.
  The count is right, but all four `Functional MySQL 8.0 …` steps sit inside a
  fully `#`-commented `testsuite:` job in both branch-1 workflows. They are
  **dormant**, not live — a latent-correctness cleanup, not "MySQL is silently
  never tested", and it cannot be validated by a green pipeline. `main` has no
  functional steps at all, commented or otherwise.
* The issue quotes branch `1`'s getopts string as `":s:a:d:p:t:e:xy:nhuv"`; it is
  actually `":s:a:d:p:t:e:xnhuv"` (no `y:`). The conclusion — no `-b`, unknown
  option exits 1 — holds.

## Separate follow-ups (deliberately not fixed here)

Two out-of-scope copy-paste leftovers in `main:Build/Scripts/runTests.sh`,
harmless today but each deserving its own ticket:

1. `COMPOSER_ROOT_VERSION="5.x.x-dev"` on a 2.0.x branch.
2. `NETWORK="fgtclb-filerequiredattributes-${SUFFIX}"` — the container network,
   and therefore the container names, are named after a different extension.

## Verification

Static plus CI; the functional suites were not run locally.

* `bash -n Build/Scripts/runTests.sh` — clean.
* All `.github/workflows/*.yml` parse with `yaml.safe_load`.
* `git diff --name-only origin/main..HEAD` → `Build/Scripts/runTests.sh` only.
  `git diff --stat origin/main..HEAD -- .github/` is empty, so no job, step,
  matrix entry or trigger could have moved.
* Structural YAML comparison of every workflow (including
  `documentation.yml.disabled`) against `origin/main`, everything except `run`
  strings: identical.
* **Behavioural check of the expansion**, not a grep: `runTests.sh` was executed
  against a stub `docker`/`podman` on `PATH` that echoes its arguments, with
  `CI=true`, for both container binaries and ten suites, on `origin/main` and on
  this branch. Exactly three command lines differ, all intended — the two
  `renderDocumentation` lines lose ` -it ` and the duplicated `-v`, and the
  docker sqlite `--tmpfs` gains `uid=1000,gid=1000` while keeping `mode=1777`.
  The podman sqlite line and `functional -d mariadb`, `unit`, `composerInstall`,
  `cgl`, `phpstan`, `lintPhp` are byte-identical.
* Asserted on the comment-stripped script: the sqlite `--tmpfs` option token is
  exactly `${TMPFS_MOUNT_OPTIONS}`; there are exactly two assignments of it with
  the values above; the `renderDocumentation` line contains no `-it` and no `-v`;
  and `CONTAINER_INTERACTIVE="-it --init"`, `USERSET`, `CI_PARAMS` and the
  `-b docker` flags are untouched.

## Acceptance

* Functional sqlite under docker owns its tmpfs by uid and gid, independent of
  the host umask; podman behaviour is unchanged.
* `renderDocumentation` runs unattended without a tty, so
  `documentation.yml.disabled` can be enabled in a later, separate change.
* No workflow content changed; the diff is one file.
